### PR TITLE
add getChainMeta

### DIFF
--- a/src/rpc-method/browser-rpc-method.js
+++ b/src/rpc-method/browser-rpc-method.js
@@ -5,11 +5,14 @@ import type {
   IGetAccountResponse,
   IGetBlockMetasRequest,
   IGetBlockMetasResponse,
+  IGetChainMetaRequest,
+  IGetChainMetaResponse,
   ISuggestGasPriceRequest,
   ISuggestGasPriceResponse} from './types';
 import {
   GetAccountRequest,
   GetBlockMetasRequest,
+  GetChainMetaRequest,
   SuggestGasPriceRequest} from './types';
 
 export default class RpcMethod {
@@ -29,6 +32,12 @@ export default class RpcMethod {
     const pbReq = GetBlockMetasRequest.to(req);
     const pbResp = await this.client.getBlockMetas(pbReq);
     return GetBlockMetasRequest.from(pbResp);
+  }
+
+  async getChainMeta(req: IGetChainMetaRequest): Promise<IGetChainMetaResponse> {
+    const pbReq = GetChainMetaRequest.to(req);
+    const pbResp = await this.client.getBlockMetas(pbReq);
+    return GetChainMetaRequest.from(pbResp);
   }
 
   async suggestGasPrice(req: ISuggestGasPriceRequest): Promise<ISuggestGasPriceResponse> {

--- a/src/rpc-method/types.js
+++ b/src/rpc-method/types.js
@@ -63,13 +63,13 @@ export class GetAccountRequest {
 }
 
 // interface for get chain meta
-interface IEpochData {
+export interface IEpochData {
   num?: number | null,
   height?: number | null,
   beaconChainHeight?: number | null,
 }
 
-interface IChainMeta {
+export interface IChainMeta {
   height?: string | null,
   supply?: string | null,
   numActions?: string | null,
@@ -82,6 +82,30 @@ export interface IGetChainMetaRequest {
 
 export interface IGetChainMetaResponse {
   chainMeta?: IChainMeta | null
+}
+
+export class GetChainMetaRequest {
+  static to(req: IGetChainMetaRequest): any {
+    return new apiPb.GetChainMetaRequest();
+  }
+
+  static from(pbRes: any): IGetChainMetaResponse {
+    const meta = pbRes.getChainMeta();
+    const res = {
+      chainMeta: meta,
+    };
+    if (meta) {
+      const epochData = meta.getEpoch();
+      res.chainMeta = {
+        height: meta.getHeight(),
+        supply: meta.getSupply(),
+        numActions: meta.getNumactions(),
+        tps: meta.getTps(),
+        epoch: epochData,
+      };
+    }
+    return res;
+  }
 }
 
 // interface for get block metas

--- a/src/rpc-method/types.js
+++ b/src/rpc-method/types.js
@@ -90,7 +90,7 @@ export class GetChainMetaRequest {
   }
 
   static from(pbRes: any): IGetChainMetaResponse {
-    const meta = pbRes.getChainMeta();
+    const meta = pbRes.getChainmeta();
     const res = {
       chainMeta: meta,
     };


### PR DESCRIPTION
1. in types.js, is `export` forgot on line 66 and 72?
2. how to find which function is available for meta.xxx()? I searched the whole code base, only see some usage in blockchain_pb.js (search `getNumactions()` for example)