### PR TITLE
Fix wrong slice of args passed to pureEncodeMethod

### DIFF
--- a/src/contract/contract.ts
+++ b/src/contract/contract.ts
@@ -116,7 +116,7 @@ export class Contract {
             execution: this.pureEncodeMethod(
               "0",
               func,
-              ...args.slice(0, args.length - 1)
+              ...args.slice(0, args.length)
             ),
             callerAddress: this.address
           });


### PR DESCRIPTION
...args.slice(0, args.length-1) selects one parameter less then required, e.g. if args.length is 1, the slice would contain no arguments instead of 1 and the method call would eventually fail.

**What type of PR is this?**

> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

> /kind bug

**What this PR does / why we need it**:
Fix wrong slice indexing that lead to call a contract method with wrong number of parameters
 
**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
